### PR TITLE
bugfix: option `[General]/Class=` is optional

### DIFF
--- a/bt_dualboot/__meta__.py
+++ b/bt_dualboot/__meta__.py
@@ -2,5 +2,5 @@ APP_NAME = "bt-dualboot"
 
 # NOTE: don't edit here
 #       version updated by `dev/pre-release/update-version` from `pyproject.toml`
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 

--- a/bt_dualboot/bt_linux/bluetooth_device_factory.py
+++ b/bt_dualboot/bt_linux/bluetooth_device_factory.py
@@ -35,7 +35,7 @@ def extract_info(device_info_path):
     # fmt: off
     return {
         "name":         config.get("General", "Name"),
-        "class":        config.get("General", "Class"),
+        "class":        config.get("General", "Class", fallback=None),
         "pairing_key":  config.get("LinkKey", "Key"),
     }
     # fmt: on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bt-dualboot"
-version = "1.0.0"
+version = "1.0.1"
 description = "Sync Bluetooth for dualboot Linux and Windows"
 keywords = [ "bluetooth", "dualboot", "sync", "pairing", "keys" ]
 authors = ["Konstantin Ivanov <KEIvanov@gmail.com>"]

--- a/tests/bt_linux/data_samples/bt_sample_01/A4:6B:6C:9D:E2:FB/A4:BF:C6:D0:E5:FF/info
+++ b/tests/bt_linux/data_samples/bt_sample_01/A4:6B:6C:9D:E2:FB/A4:BF:C6:D0:E5:FF/info
@@ -1,6 +1,5 @@
 [General]
 Name=DEV-1-01-Name
-Class=0x240404
 SupportedTechnologies=BR/EDR;
 Trusted=true
 Blocked=false

--- a/tests_integration/cli/env_blank_linux/snapshots/test_cli/test_no_args/output
+++ b/tests_integration/cli/env_blank_linux/snapshots/test_cli/test_no_args/output
@@ -7,7 +7,7 @@ usage: bt-dualboot [-h] [--version] [-l] [--list-win-mounts] [--bot]
                    [--dry-run] [--win MOUNT] [--sync MAC [MAC ...]]
                    [--sync-all] [-n] [-b [path]]
 
-Sync bluetooth keys from Linux to Windows (v1.0.0)
+Sync bluetooth keys from Linux to Windows (v1.0.1)
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/tests_integration/cli/env_blank_linux/snapshots/test_cli/test_version/output
+++ b/tests_integration/cli/env_blank_linux/snapshots/test_cli/test_version/output
@@ -3,7 +3,7 @@ CMD: /src/bt-dualboot --version
 RETCODE=0
 STDOUT:
 =======
-bt-dualboot 1.0.0
+bt-dualboot 1.0.1
 
 -------------------------------------------------------------
 STDERR:

--- a/tests_integration/cli/env_single_windows/snapshots/test_cli/test_no_args/output
+++ b/tests_integration/cli/env_single_windows/snapshots/test_cli/test_no_args/output
@@ -7,7 +7,7 @@ usage: bt-dualboot [-h] [--version] [-l] [--list-win-mounts] [--bot]
                    [--dry-run] [--win MOUNT] [--sync MAC [MAC ...]]
                    [--sync-all] [-n] [-b [path]]
 
-Sync bluetooth keys from Linux to Windows (v1.0.0)
+Sync bluetooth keys from Linux to Windows (v1.0.1)
 
 optional arguments:
   -h, --help            show this help message and exit


### PR DESCRIPTION
As reported by https://github.com/x2es/bt-dualboot/issues/3, looks like option `[General]/Class=` from `/var/lib/bluetooth/ADAPTER_MAC/DEVICE_MAC/info` may be optional.

* [x] tests passed
* [x] publish pip as v1.0.1