### PR TITLE
bugfix: format string for problem_devices_macs

### DIFF
--- a/bt_dualboot/bt_sync_manager/bt_sync_manager.py
+++ b/bt_dualboot/bt_sync_manager/bt_sync_manager.py
@@ -72,7 +72,7 @@ class BtSyncManager:
         if len(problem_devices_macs) > 0:
             # fmt: off
             print(
-                "WARNING: Following devices paired on Linux for multiple BT-adapters: {", ".join(problem_devices_macs)}",
+                f'WARNING: Following devices paired on Linux for multiple BT-adapters: {", ".join(problem_devices_macs)}',
                 file=sys.stderr
             )
             # fmt: on
@@ -87,7 +87,7 @@ class BtSyncManager:
         if len(problem_devices_macs) > 0:
             # fmt: off
             print(
-                "WARNING: Following devices paired on Windows for multiple BT-adapters: {", ".join(problem_devices_macs)}",
+                f'WARNING: Following devices paired on Windows for multiple BT-adapters: {", ".join(problem_devices_macs)}',
                 file=sys.stderr
             )
             # fmt: on


### PR DESCRIPTION
`BtSyncManager._index_devices()` outputted a bare string instead of a formatted string for `problem_devices_macs`